### PR TITLE
Add NEU-tts-2022 project as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "NEU-tts-2022"]
+	path = NEU-tts-2022
+	url = https://github.com/roedoejet/NEU-tts-2022.git


### PR DESCRIPTION
I add our FastSpeech2 project (https://github.com/roedoejet/NEU-tts-2022) as a submodule, so that the backend can use the inference code easily while the two projects remain separate. 