### PR TITLE
Add text2phones handler

### DIFF
--- a/backend/NEU-tts-2022/audio_handler.py
+++ b/backend/NEU-tts-2022/audio_handler.py
@@ -40,8 +40,12 @@ def Text2PhoneHandler():
     kwargs = {}
     request_dict = json.loads(request.get_data())
     print(request_dict)
+
+    if 'text' not in request_dict:
+        return '`text` param not provided', 400
+    
     kwargs['text'] = request_dict.get('text')
-    kwargs['lex_path'] = request_dict.get('lex_path')
+    kwargs['lex_path'] = request_dict.get('lex_path', "lexicon/librispeech-lexicon.txt")
 
     result = text2phones.get_phones(**kwargs)
     response = make_response(result)

--- a/backend/NEU-tts-2022/audio_handler.py
+++ b/backend/NEU-tts-2022/audio_handler.py
@@ -2,6 +2,7 @@ from flask import Flask, send_file, request, make_response
 import json
 import sys
 import synthesize  
+import text2phones
 
 app = Flask(__name__)
 
@@ -30,5 +31,19 @@ def AudioHandler():
             mimetype='audio/wav'
         )
     )
+    response.headers['Access-Control-Allow-Origin'] = '*'
+    return response
+
+
+@app.route('/get_phones', methods=['POST'])
+def Text2PhoneHandler():
+    kwargs = {}
+    request_dict = json.loads(request.get_data())
+    print(request_dict)
+    kwargs['text'] = request_dict.get('text')
+    kwargs['lex_path'] = request_dict.get('lex_path')
+
+    result = text2phones.get_phones(**kwargs)
+    response = make_response(result)
     response.headers['Access-Control-Allow-Origin'] = '*'
     return response


### PR DESCRIPTION
Add a `Text2PhoneHandler` that hosts a service to provide text2phone function using `http://hostname/get_phones`.

Example usage:

```python
import requests

URL = "http://localhost:5000/get_phones"

data = {'text': "How are you bro", "lex_path": "lexicon/librispeech-lexicon.txt"}
r = requests.post(url=URL, json=data)
json = r.json()

print(json)
```
