### PR TITLE
Allow control values as list

### DIFF
--- a/backend/NEU-tts-2022/model/modules.py
+++ b/backend/NEU-tts-2022/model/modules.py
@@ -82,6 +82,12 @@ class VarianceAdaptor(nn.Module):
         if target is not None:
             embedding = self.pitch_embedding(torch.bucketize(target, self.pitch_bins))
         else:
+            try:
+                control = eval(control)
+                assert isinstance(control, list)
+                control = torch.tensor(control).to(prediction.device)
+            except Exception as e:
+                pass
             prediction = prediction * control
             embedding = self.pitch_embedding(
                 torch.bucketize(prediction, self.pitch_bins)
@@ -93,6 +99,12 @@ class VarianceAdaptor(nn.Module):
         if target is not None:
             embedding = self.energy_embedding(torch.bucketize(target, self.energy_bins))
         else:
+            try:
+                control = eval(control)
+                assert isinstance(control, list)
+                control = torch.tensor(control).to(prediction.device)
+            except Exception as e:
+                pass
             prediction = prediction * control
             embedding = self.energy_embedding(
                 torch.bucketize(prediction, self.energy_bins)
@@ -129,6 +141,12 @@ class VarianceAdaptor(nn.Module):
             x, mel_len = self.length_regulator(x, duration_target, max_len)
             duration_rounded = duration_target
         else:
+            try:
+                d_control = eval(d_control)
+                assert isinstance(d_control, list)
+                d_control = torch.tensor(d_control).to(log_duration_prediction.device)
+            except Exception as e:
+                pass
             duration_rounded = torch.clamp(
                 (torch.round(torch.exp(log_duration_prediction) - 1) * d_control),
                 min=0,

--- a/backend/NEU-tts-2022/synthesize.py
+++ b/backend/NEU-tts-2022/synthesize.py
@@ -229,19 +229,19 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--pitch_control",
-        type=float,
+        # type=float,
         default=1.0,
         help="control the pitch of the whole utterance, larger value for higher pitch",
     )
     parser.add_argument(
         "--energy_control",
-        type=float,
+        # type=float,
         default=1.0,
         help="control the energy of the whole utterance, larger value for larger volume",
     )
     parser.add_argument(
         "--duration_control",
-        type=float,
+        # type=float,
         default=1.0,
         help="control the speed of the whole utterance, larger value for slower speaking rate",
     )


### PR DESCRIPTION
Usage example:

`
python synthesize.py --text "Hello there" --restore_step 900000 --mode single -p config/LJSpeech/preprocess.yaml -m config/LJSpeech/model.yaml -t config/LJSpeech/train.yaml --duration_control "[1, 1, 1, 1, 3, 3, 7]" --energy_control 0.8
`